### PR TITLE
Remove `version` property from `composer.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Increase minimum version of `slevomat/coding-standard` dependency to 7.1 (fixes #4)
+- Remove `version` property from `composer.json`
 
 ## [29.0.1]
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
     },
     "description": "iO PHP_CodeSniffer Standard",
     "type": "phpcodesniffer-standard",
-    "version": "29.0.1",
     "license": "MIT",
     "require": {
         "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",


### PR DESCRIPTION
According to the [Composer JSON schema documentation of the `version` property](https://getcomposer.org/doc/04-schema.md#version):

>  Optional if the package repository can infer the version from somewhere, such as the VCS tag name in the VCS repository. In that case it is also recommended to omit it.