### PR TITLE
Remove PHP 7.4 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,6 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - "7.4"
                     - "8.0"
                     - "8.1"
                     - "8.2"

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,12 +1,5 @@
 name: 'php-code-sniffer-standard'
 services:
-    php74:
-        type: 'php:7.4'
-        xdebug: true
-        overrides:
-            environment:
-                PHP_IDE_CONFIG: 'serverName=appserver'
-                XDEBUG_TRIGGER: '1'
     php80:
         type: 'php:8.0'
         xdebug: true
@@ -31,7 +24,6 @@ services:
 tooling:
     phpunit:
         cmd:
-            -   php74: 'vendor/bin/phpunit'
             -   php80: 'vendor/bin/phpunit'
             -   php81: 'vendor/bin/phpunit'
             -   php82: 'vendor/bin/phpunit'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for PHP 8.3
 - Add support for v1 versions of the `dealerdirect/phpcodesniffer-composer-installer` package
 
+### Removed
+- Dropped support for PHP 7.4
+
 ### Fixed
 - Increase minimum version of `slevomat/coding-standard` dependency to 7.1 (fixes #4)
 - Remove `version` property from `composer.json`

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "type": "phpcodesniffer-standard",
     "license": "MIT",
     "require": {
-        "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
         "slevomat/coding-standard": "^7.1 || ^8.0",
         "squizlabs/php_codesniffer": "^3.6.0",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,8 +4,8 @@
     <file>tests</file>
     <rule ref="IO"/>
 
-    <config name="php_version" value="70400"/>
-    <config name="testVersion" value="7.4-8.3"/>
+    <config name="php_version" value="80000"/>
+    <config name="testVersion" value="8.0-8.3"/>
 
     <arg name="extensions" value="php"/>
     <arg name="cache"/>


### PR DESCRIPTION
PHP 7.4 is end-of-life since 28-11-2022.