### PR TITLE
Add support for slevomat/coding-standard:^8.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add support for `slevomat/coding-standard:^8.15`, replace usages of `UseStatementHelper::isAnonymousFunctionUse` with `UseStatementHelper::!isImportUse`
+
 ## [v29.1.0] - 2023-12-12
 ### Added
 - Add support for PHP 8.3

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
-        "slevomat/coding-standard": "^7.1 || ^8.0",
+        "slevomat/coding-standard": "^8.15",
         "squizlabs/php_codesniffer": "^3.6.0",
         "phpcompatibility/php-compatibility": "^9.3"
     },

--- a/src/Standards/IO/Sniffs/Namespaces/MultipleLinesPerUseSniff.php
+++ b/src/Standards/IO/Sniffs/Namespaces/MultipleLinesPerUseSniff.php
@@ -30,7 +30,7 @@ class MultipleLinesPerUseSniff implements Sniff
      */
     public function process(File $phpcsFile, $usePointer)
     {
-        if (UseStatementHelper::isAnonymousFunctionUse($phpcsFile, $usePointer)) {
+        if (!UseStatementHelper::isImportUse($phpcsFile, $usePointer)) {
             return;
         }
 


### PR DESCRIPTION
isAnonymousFunctionUse is replaced by isImportUse in slevomat/coding-standard v8.15.0